### PR TITLE
Fix compilation errors with GCC 14

### DIFF
--- a/vstgui/lib/finally.h
+++ b/vstgui/lib/finally.h
@@ -18,7 +18,7 @@ public:
 	FinalAction (FinalAction&& other) noexcept
 	{
 		action = std::move (other.action);
-		other.invoke (false);
+		other.invoke = false;
 	}
 	FinalAction (const FinalAction&) = delete;
 	FinalAction& operator= (const FinalAction&) = delete;


### PR DESCRIPTION
Fixes sfztools/sfizz-ui#139.

GCC 14 improved error detection in non-instantiated templates, and as a result, a previously ignored [invalid line of code](https://github.com/steinbergmedia/vstgui/blob/1ca48defdb056600e9e2121f717c2be29c5220ab/vstgui/lib/finally.h#L21) in VSTGUI now causes compilation errors.

This issue has already been reported (steinbergmedia#324) and [fixed](https://github.com/steinbergmedia/vstgui/commit/7cc6b0e0ab9b7dd5b98f71e74d7c75694761538a) upstream. This PR simply cherry-picks that fix.